### PR TITLE
Change description to not override Gnome display manager in search bar

### DIFF
--- a/spotlight.desktop
+++ b/spotlight.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Spotlight
-Comment=Displays a new background image
+Comment=Fetch a new background image from Spotlight
 Keywords=background;wallpaper;
 Exec=spotlight.sh
 Icon=preferences-desktop-wallpaper


### PR DESCRIPTION
Currently, searching for “display” in Gnome’s search bar shows Spotlight over Gnome’s default display manager. This is slightly annoying, especially when attempting to blindly fix broken display settings.

This fix changes the wording to avoid this issue.