### PR TITLE
Modified service file to not use absolute path for spotlight.sh

### DIFF
--- a/spotlight.service
+++ b/spotlight.service
@@ -5,4 +5,4 @@ After=network-online.target graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/spotlight.sh
+ExecStart=/usr/bin/env bash spotlight.sh


### PR DESCRIPTION
Modified service file to avoid using the absolute path as the file `/usr/bin/spotlight.sh` doesn't exist in case of a local installation