### PR TITLE
Added possibility to store the images in custom paths

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Marius Knaust <marius.knaust@gmail.com>
+# Contributor: dpellegr
+
+pkgname=spotlight
+pkgver=32.64dc1db
+pkgrel=1
+pkgdesc="Displays a new background image daily"
+arch=('any')
+license=('GPL')
+url="https://github.com/dpellegr/spotlight"
+install=spotlight.install
+depends=('wget'
+         'jq'
+         'gnome-settings-daemon'
+         'libsystemd')
+source=('git+https://github.com/dpellegr/spotlight.git')
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$pkgname"
+  printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+ 
+package()
+{
+	install -m755 -D ${srcdir}/spotlight/spotlight.sh ${pkgdir}/usr/bin/spotlight.sh
+	install -m644 -D ${srcdir}/spotlight/spotlight.service ${pkgdir}/usr/lib/systemd/user/spotlight.service
+	install -m644 -D ${srcdir}/spotlight/spotlight.timer ${pkgdir}/usr/lib/systemd/user/spotlight.timer
+	install -m644 -D ${srcdir}/spotlight/spotlight.desktop ${pkgdir}/usr/share/applications/spotlight.desktop
+	install -m644 -D ${srcdir}/spotlight/spotlight.conf ${pkgdir}/etc/spotlight.conf
+}
+

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Use the system log to get the past image descriptions, e.g. for the the current 
 
 spotlight.sh accepts the following command line options:
 
- * -h shows this message
- * -p specifies a working path. Defaults to "/home/dario/.local/share/spotlight"
+ * -h shows a small help message
+ * -p specifies a working path. Defaults to "$HOME/.local/share/spotlight"
  * -s stores the images into the folder path/archive/
 
 You can test them by calling `spotlight.sh` from a terminal and/or add them in the `spotlight.service` file at the end of the `ExecStart=` line. Adding a small config file would be nice...

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ To trigger it manually you can either use the desktop entry by looking for _spot
 
 Use the system log to get the past image descriptions, e.g. for the the current background `journalctl -t spotlight -n 1`.
 
-## Options
+## Configuration
 
-spotlight.sh accepts the following command line options:
+Spotlight does not require particular configuration.
+
+However, while the default behaviour of spotlight is to discard the images that it downloads, this can be changed by means of the `/etc/spotlight.conf` file.
+
+In addition, for quick testing, the same options can be passed on the line options when calling spotlight.sh directly:
 
  * -h shows a small help message
  * -p specifies a working path. Defaults to "$HOME/.local/share/spotlight"
  * -s stores the images into the folder path/archive/
-
-You can test them by calling `spotlight.sh` from a terminal and/or add them in the `spotlight.service` file at the end of the `ExecStart=` line. Adding a small config file would be nice...
 
 ## Packages
 ### Arch Linux

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ To trigger it manually you can either use the desktop entry by looking for _spot
 
 Use the system log to get the past image descriptions, e.g. for the the current background `journalctl -t spotlight -n 1`.
 
+## Options
+
+spotlight.sh accepts the following command line options:
+
+ * -h shows this message
+ * -p specifies a working path. Defaults to "/home/dario/.local/share/spotlight"
+ * -s stores the images into the folder path/archive/
+
+You can test them by calling `spotlight.sh` from a terminal and/or add them in the `spotlight.service` file at the end of the `ExecStart=` line. Adding a small config file would be nice...
+
 ## Packages
 ### Arch Linux
 [aur/spotlight](https://aur.archlinux.org/packages/spotlight/)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Use the system log to get the past image descriptions, e.g. for the the current 
 
 Spotlight does not require particular configuration.
 
-However, while the default behaviour of spotlight is to discard the images that it downloads, this can be changed by means of the `/etc/spotlight.conf` file.
+The default behaviour of spotlight is to discard the images that it downloads. The `/etc/spotlight.conf` file allows to alter this, by storing the images in the spotlight working path.
 
-In addition, for quick testing, the same options can be passed on the line options when calling spotlight.sh directly:
+The settings specified in the config file can be overridden when calling spotlight.sh directly from the terminal:
 
  * -h shows a small help message
  * -p specifies a working path. Defaults to "$HOME/.local/share/spotlight"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Spotlight does not require particular configuration.
 
 However, while the default behaviour of spotlight is to discard the images that it downloads, this can be changed by means of the `/etc/spotlight.conf` file.
 
-In addition, for quick testing, the same options can be passed on the line options when calling spotlight.sh directly:
+In addition, for quick testing, the same options can be passed on the command line when calling `spotlight.sh` directly:
 
  * -h shows a small help message
  * -p specifies a working path. Defaults to "$HOME/.local/share/spotlight"

--- a/spotlight.conf
+++ b/spotlight.conf
@@ -1,0 +1,6 @@
+# specify a custom path instead of $HOME/.local/share/spotlight
+#dataPath="/home/me/spotlight"
+
+# Store the old images instead of discarding them
+#store=true
+

--- a/spotlight.sh
+++ b/spotlight.sh
@@ -5,18 +5,21 @@ store=false
 
 while getopts ":hp:s" opt; do
   case ${opt} in
-    h ) echo "spotlight.sh - Windows 10 Spotlight Background images for Gnome"
+    h ) echo ""
+        echo "spotlight.sh - Windows 10 Spotlight Background images for Gnome"
         echo ""
         echo "Options:"
         echo "  -h shows this message"
         echo "  -p specifies a working path. Defaults to \"$HOME/.local/share/spotlight\""
-        echo "  -s stores the images at path/archive/"
+        echo "  -s stores the images into the folder path/archive/"
+        exit 1
       ;;
     p ) dataPath=$OPTARG
       ;;
     s ) store=true
       ;;
-    \? ) echo "Usage: spotlight.sh [-p working path] [-s save images]"
+    \? ) echo "Usage: spotlight.sh [-h additional help] [-p working path] [-s store images]"
+         exit 2
       ;;
   esac
 done

--- a/spotlight.sh
+++ b/spotlight.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 
 dataPath="${XDG_DATA_HOME:-$HOME/.local/share}/spotlight"
+store=false
+
+while getopts ":hp:s" opt; do
+  case ${opt} in
+    h ) echo "spotlight.sh - Windows 10 Spotlight Background images for Gnome"
+        echo ""
+        echo "Options:"
+        echo "  -h shows this message"
+        echo "  -p specifies a working path. Defaults to \"$HOME/.local/share/spotlight\""
+        echo "  -s stores the images at path/archive/"
+      ;;
+    p ) dataPath=$OPTARG
+      ;;
+    s ) store=true
+      ;;
+    \? ) echo "Usage: spotlight.sh [-p working path] [-s save images]"
+      ;;
+  esac
+done
 
 function decodeURL
 {
@@ -21,13 +40,13 @@ item=$(jq -r ".batchrsp.items[0].item" <<< $response)
 landscapeUrl=$(jq -r ".ad.image_fullscreen_001_landscape.u" <<< $item)
 sha256=$(jq -r ".ad.image_fullscreen_001_landscape.sha256" <<< $item | base64 -d | hexdump -ve "1/1 \"%.2x\"")
 title=$(jq -r ".ad.title_text.tx" <<< $item)
-searchTerms=$(jq -r ".ad.title_destination_url.u" <<< $item | sed 's/.*q=\([^&]*\).*/\1/' | decodeURL)
+searchTerms=$(jq -r ".ad.title_destination_url.u" <<< $item | perl -pe 's/.*?q=(.*?)&.*/\1/' | decodeURL)
 
 mkdir -p "$dataPath"
-path="$dataPath/background.jpg"
+img="$dataPath/current_background.jpg"
 
-wget -qO "$path" "$landscapeUrl"
-sha256calculated=$(sha256sum $path | cut -d " " -f 1)
+wget -qO "$img" "$landscapeUrl"
+sha256calculated=$(sha256sum $img | cut -d " " -f 1)
 
 if [ "$sha256" != "$sha256calculated" ]
 then
@@ -35,8 +54,14 @@ then
 	exit 1
 fi
 
+if [ "$save" = true ] 
+then
+        mkdir -p "$dataPath/archive"
+	cp "$img" "$dataPath/archive/$(date +%Y%m%d) $title ($searchTerms).jpg"
+fi
+
 gsettings set "org.gnome.desktop.background" picture-options "zoom"
-gsettings set "org.gnome.desktop.background" picture-uri "file://$path"
+gsettings set "org.gnome.desktop.background" picture-uri "file://$img"
 
 notify-send "Background changed" "$title ($searchTerms)" --icon=preferences-desktop-wallpaper --urgency=low #--hint=string:desktop-entry:spotlight
 systemd-cat -t spotlight -p info <<< "Background changed to $title ($searchTerms)"

--- a/spotlight.sh
+++ b/spotlight.sh
@@ -70,8 +70,10 @@ fi
 
 if [ "$save" = true ] 
 then
-        mkdir -p "$dataPath/archive"
-	cp "$img" "$dataPath/archive/$(date +%Y%m%d) $title ($searchTerms).jpg"
+	stored_img="$dataPath/archive/$(date +%Y%m%d) $title ($searchTerms).jpg"
+	mkdir -p "$dataPath/archive"
+	mv "$img" "$stored_img"
+	ln -sfn "$stored_img" "$img"
 fi
 
 gsettings set "org.gnome.desktop.background" picture-options "zoom"

--- a/spotlight.sh
+++ b/spotlight.sh
@@ -54,7 +54,7 @@ item=$(jq -r ".batchrsp.items[0].item" <<< $response)
 landscapeUrl=$(jq -r ".ad.image_fullscreen_001_landscape.u" <<< $item)
 sha256=$(jq -r ".ad.image_fullscreen_001_landscape.sha256" <<< $item | base64 -d | hexdump -ve "1/1 \"%.2x\"")
 title=$(jq -r ".ad.title_text.tx" <<< $item)
-searchTerms=$(jq -r ".ad.title_destination_url.u" <<< $item | perl -pe 's/.*?q=(.*?)&.*/\1/' | decodeURL)
+searchTerms=$(jq -r ".ad.title_destination_url.u" <<< $item | sed 's/.*q=\([^&]*\).*/\1/' | decodeURL)
 
 mkdir -p "$dataPath"
 img="$dataPath/current_background.jpg"

--- a/spotlight.sh
+++ b/spotlight.sh
@@ -68,7 +68,7 @@ then
 	exit 1
 fi
 
-if [ "$save" = true ] 
+if [ "$store" = true ] 
 then
 	stored_img="$dataPath/archive/$(date +%Y%m%d) $title ($searchTerms).jpg"
 	mkdir -p "$dataPath/archive"

--- a/spotlight.sh
+++ b/spotlight.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 
-dataPath="${XDG_DATA_HOME:-$HOME/.local/share}/spotlight"
-store=false
+conf_file=/etc/spotlight.conf
+
+if [ -f "$conf_file" ]; then
+	source "$conf_file"
+fi
+
+if [ -z "$dataPath" ]; then
+	dataPath="${XDG_DATA_HOME:-$HOME/.local/share}/spotlight"
+fi
+
+if [ -z "$store" ]; then
+	store=false
+fi
 
 while getopts ":hp:s" opt; do
   case ${opt} in


### PR DESCRIPTION
Hi and thank you for the very cool script.

I have been enjoying it for a while, but sometimes I regretted that a particularly beautiful image was discarded. I modified the script a bit and added a configuration file allowing to specify a custom working path and the possibility to store the images in it. The default behavior of discarding the images is unchanged.

Also in the PKGBUILD you can drop the perl dependency now!